### PR TITLE
Make urj into library; Add noClobber option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Features
 - Sets `public-read`
 - Supports OS X and Linux
 - Requires Python 2.7 and [baiji][]
+- Can be used via a CLI or as a NodeJS library
 
 [baiji]: https://github.com/bodylabs/baiji
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+var Publisher = require('./src/publisher'),
+    compress = require('./src/compress');
+
+module.exports = {
+    Publisher: Publisher,
+    compress: compress,
+};
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "urj",
   "description": "Static web publishing using S3",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "BSD-2-Clause",
   "main": "./index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Static web publishing using S3",
   "version": "1.0.0",
   "license": "BSD-2-Clause",
-  "main": null,
+  "main": "./index.js",
   "bin": {
     "urj": "./src/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "Static web publishing using S3",
   "version": "1.1.0",
   "license": "BSD-2-Clause",
-  "main": "./index.js",
   "bin": {
     "urj": "./src/cli.js"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@ var Publisher = require('../src/publisher'),
     program = require('commander');
 
 program
-    .version('1.0')
+    .version('1.1')
     .arguments('<source> <target>')
     .option('-n, --no-clobber', 'Do not overwrite any existing release')
     .action(function (source, target) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,8 +6,9 @@ var Publisher = require('../src/publisher'),
 program
     .version('1.0')
     .arguments('<source> <target>')
+    .option('-n, --no-clobber', 'Do not overwrite any existing release')
     .action(function (source, target) {
-        var publisher = new Publisher();
+        var publisher = new Publisher({ noClobber: program.noClobber });
         publisher.publish(source, target, function (err) {
             if (err) {
                 throw err;

--- a/src/publisher.impl.js
+++ b/src/publisher.impl.js
@@ -32,7 +32,7 @@ var execWithInheritedStdio = function (command, callback) {
 var Publisher = function (options) {
     options = options || {};
     this.compress = options.compress === undefined ? true : options.compress;
-    this.noClobber = !! options.noClobber;
+    this.noClobber = Boolean(options.noClobber);
 };
 
 Publisher.prototype.publish = function (srcPath, dstPath, doneCallback) {

--- a/src/publisher.impl.js
+++ b/src/publisher.impl.js
@@ -43,7 +43,9 @@ Publisher.prototype.publish = function (srcPath, dstPath, doneCallback) {
             var command = 's3 ls ' + dstPath;
 
             childProcess.exec(command, {}, function (err, stdout) {
-                if (stdout.indexOf(dstPath) != -1) {
+                if (err) {
+                    callback(err);
+                } else if (stdout.indexOf(dstPath) !== -1) {
                     callback(new Error('The path "' + dstPath + '" already exists.'));
                 } else {
                     callback();

--- a/src/publisher.impl.js
+++ b/src/publisher.impl.js
@@ -40,6 +40,8 @@ Publisher.prototype.publish = function (srcPath, dstPath, doneCallback) {
 
     if (this.noClobber) {
         fns.push(function (callback) {
+            // List all keys that contain dstPath. If any are found, then dstPath exists
+            // and we don't want to publish.
             var command = 's3 ls ' + dstPath;
 
             childProcess.exec(command, {}, function (err, stdout) {

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -5,6 +5,7 @@ var cc = _(require('./common-contracts')).clone();
 
 cc.publisherOptions = c.toContract({
     compress: c.optional(c.bool),
+    noClobber: c.optional(c.bool),
 }).rename('publisherOptions');
 
 // Publish some files to S3.


### PR DESCRIPTION
This was done to support the development of [`vurj`](https://github.com/bodylabs/vurj), which needs to have `urj` bail out of a deploy if that release already exists. It was also easier to interact with `urj` if it was a library, so I made it into one.

@paulmelnikow